### PR TITLE
Added entry point to docs and the MS-Math project

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,0 +1,28 @@
+# math-a11y
+
+The [DAISY math-a11y GitHub repository](https://github.com/daisy/math-a11y) is focused on advancing the reading and writing of mathematics for persons with disabilities. Blind and low vision users are the target audience. We will work to make sure the Reading Systems, browsers, and authoring tools 
+perform as expected. We will engage with the authoring tool , Reading Systems, and Assistive Technology (AT) developers to improve the experience.
+
+In addition, we will identify the training and support materials needed for end users to advance their skills in mathematics. Where these resources already exist, we will reference them. When there are materials not available, we will create those resources.
+
+We plan to collaborate with other groups working on the advancement of mathematics for persons with disabilities.
+
+## Communications
+
+We are using a DAISY mailing list for our communications.
+
+[Accessible Math math@daisylists.org](mailto:math@daisylists.org)
+
+[To sign up to the DAISY Math list discussing reading and writing accessible math, fill out this simple form.](https://daisylists.org/postorius/lists/math.daisylists.org/)
+
+We are also using a SharePoint folder for documents. Members can request this link.
+
+## Projects
+
+We plan to work on a number of projects associated with the reading and writing of math. We will list them here:
+
+### [Microsoft Word 365](./docs/ms-math/)
+
+We are collaborating with developers at Microsoft.
+
+If you are posting a message to the mailing list and want to focus on this project, please begin the subject line with "[MS-Math]"


### PR DESCRIPTION
I am trying to get a link into the MS-Math project. Other projects should be made available in the same way. I am following Brian's model.
