### PR TITLE
Fixed the email link in index and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ We plan to collaborate with other groups working on the advancement of mathemati
 
 We are using a DAISY mailing list for our communications.
 
-[Accessible Math math@daisylists.org](math@daisylists.org)
+Email list is: <>math@daisylists.org>
 
 [To sign up to the DAISY Math list discussing reading and writing accessible math, fill out this simple form.](https://daisylists.org/postorius/lists/math.daisylists.org/)
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ We plan to collaborate with other groups working on the advancement of mathemati
 
 We are using a DAISY mailing list for our communications.
 
-Email list is: <>math@daisylists.org>
+Email list is: <math@daisylists.org>
 
 [To sign up to the DAISY Math list discussing reading and writing accessible math, fill out this simple form.](https://daisylists.org/postorius/lists/math.daisylists.org/)
 
@@ -26,5 +26,5 @@ We plan to work on a number of projects associated with the reading and writing 
 We are collaborating with developers at Microsoft.
 
 If you are posting a message to the mailing list and want to focus on this project, please include in the subject [MS-Math]
-]
+
 

--- a/index.md
+++ b/index.md
@@ -11,7 +11,7 @@ We plan to collaborate with other groups working on the advancement of mathemati
 
 We are using a DAISY mailing list for our communications.
 
-[Accessible Math math@daisylists.org](mailto:math@daisylists.org)
+Email  list is: <math@daisylists.org>
 
 [To sign up to the DAISY Math list discussing reading and writing accessible math, fill out this simple form.](https://daisylists.org/postorius/lists/math.daisylists.org/)
 

--- a/index.md
+++ b/index.md
@@ -13,11 +13,6 @@ We are using a DAISY mailing list for our communications.
 
 Email list is:<math@daisylists.org>
 
-
-
-
-math@daisylists.org
-
 [To sign up to the DAISY Math list discussing reading and writing accessible math, fill out this simple form.](https://daisylists.org/postorius/lists/math.daisylists.org/)
 
 We are also using a SharePoint folder for documents. Members can request this link.

--- a/index.md
+++ b/index.md
@@ -11,7 +11,12 @@ We plan to collaborate with other groups working on the advancement of mathemati
 
 We are using a DAISY mailing list for our communications.
 
-Email  list is: <math@daisylists.org>
+Email list is:<math@daisylists.org>
+
+
+
+
+math@daisylists.org
 
 [To sign up to the DAISY Math list discussing reading and writing accessible math, fill out this simple form.](https://daisylists.org/postorius/lists/math.daisylists.org/)
 


### PR DESCRIPTION
I found the correct markdown to use to put in a email address. Now clicking on the amil should launch your default email client. I changed in readme and index.md.

I thought  I would include Mary  as reviewer in the PR just for experience. However, I did not see her name in the list. may not have rights. I can look into that.