### PR TITLE
NVDA suggested settings updated

### DIFF
--- a/docs/ms-math/recommended_nvda_settings.md
+++ b/docs/ms-math/recommended_nvda_settings.md
@@ -1,9 +1,9 @@
-For the Equations in Microsoft Word Usability Walk-through, please use
+For the Equations in Microsoft Word , please use
 the following NVDA and MathCAT settings if possible.
 
 For NVDA to work with digital math content, it needs to have an add-on
 installed. The best add-on for speaking math and creating math braille
-codes in Nemeth or UEB is the MathCATAdd-on. This group’s efforts are
+codes in Nemeth or UEB is the MathCATAdd-on. The DAISY/Math-a11y group’s efforts are
 focused on evaluating how well the Microsoft Equations work in Word for
 screen reader users. To avoid stumbling across known limitations in
 screen readers, please use the following:
@@ -23,8 +23,8 @@ API, and Windows OneCore voices. All synthesizers work.
 
 1.   Open NVDA settings with NVDA key + n and arrow down to the  Tools menu and press enter.
 2. Arrow don to the Ad-on store and press enter.
-  3. Press shift  tab untill you get to the installed Add-ons and arrow over to the Available Add-ons.
-  4. Press tab untill you get to the Search field and type in MathCAT and press enter.
+  3. Press shift  tab until you get to the installed Add-ons and arrow over to the Available Add-ons.
+  4. Press tab until you get to the Search field and type in MathCAT and press enter.
   6. Press enter and confirm that you want to install.
   7. The MathCAT Add-on will be downloaded and installed.
    8.  NVDA will ask you to restart, select “Yes”
@@ -47,7 +47,7 @@ To open the MathCAT Preferences dialog in NVDA:
 4.  Select “MathCAT Settings...” and press enter.
 
 The MathCAT Preferences dialog has three categories of settings: Speech,
-Navigation, and Braille.  To move between these three collection of settings, use CTRL + tab to cycle through the options.
+Navigation, and Braille.  To move between these three collection of settings, use CTRL + tab to cycle through them. Use tab to move through the options, and arrow keys to make a selection.
 
 Below are the suggested Speech and
 Navigation settings:
@@ -73,7 +73,7 @@ Navigation settings:
 |----|----|
 | Navigation mode | Enhanced \[Default\] |
 | Navigation speech to use when beginning to navigate an equation | Speak \[Default\] |
-| Speech amount for navigation | Verbose |
+| Speech amount for navigation | medium |
 | Copy math as | MathML |
 
 # Navigating Math with MathCAT

--- a/docs/ms-math/recommended_nvda_settings.md
+++ b/docs/ms-math/recommended_nvda_settings.md
@@ -2,8 +2,8 @@ For the Equations in Microsoft Word Usability Walk-through, please use
 the following NVDA and MathCAT settings if possible.
 
 For NVDA to work with digital math content, it needs to have an add-on
-installed. The best addon for speaking math and creating math braille
-codes in Nemeth or UEB is the MathCAT plug-in. This group’s efforts are
+installed. The best add-on for speaking math and creating math braille
+codes in Nemeth or UEB is the MathCATAdd-on. This group’s efforts are
 focused on evaluating how well the Microsoft Equations work in Word for
 screen reader users. To avoid stumbling across known limitations in
 screen readers, please use the following:
@@ -39,15 +39,17 @@ To open the MathCAT Preferences dialog in NVDA:
 
 1.  Start NVDA
 2.  Use the NVDA Key + n to bring up the NVDA Menu.
-    1.  The NVDA Key is usually the INS key.
+    1.  The NVDA Key is usually the Caps lock and the INS key.
     2.  Alternatively, if using the mouse to find the NVDA icon in the
         toolbar. Note that the NVDA icon might be hidden. Use the show
         hidden icons option to bring it up.
 3.  Select "Preferences" from the NVDA Menu
-4.  Select “MathCAT Settings...”
+4.  Select “MathCAT Settings...” and press enter.
 
 The MathCAT Preferences dialog has three categories of settings: Speech,
-Navigation, and Braille. We are interested in setting the Speech and
+Navigation, and Braille.  To move between these three collection of settings, use CTRL + tab to cycle through the options.
+
+Below are the suggested Speech and
 Navigation settings:
 
 ## Speech Category Settings:
@@ -55,8 +57,14 @@ Navigation settings:
 | Setting                       | Set to                 |
 |-------------------------------|------------------------|
 | Generate Speech for           | Blindness \[Default\]  |
+| Language | auto |
+| Decimal separator for numbers | Auto|
 | Speech Style                  | ClearSpeak \[Default\] |
 | Speech Verbosity              | Verbose                |
+| Relative speech rate | Set slider lower to slow down speech |
+| Pause factor | slider  to pause between items |
+| Make a sound when starting/ending math  | check box |
+| Subject area to be used when it cannot be determined  | General |
 | Speech for chemical equations | Off (H sub 2 O)        |
 
 ## Navigation Category Settings:

--- a/docs/ms-math/recommended_nvda_settings.md
+++ b/docs/ms-math/recommended_nvda_settings.md
@@ -9,52 +9,26 @@ screen reader users. To avoid stumbling across known limitations in
 screen readers, please use the following:
 
 - Windows 10 or Windows 11
-- NVDA Version 2024.2 (2024.2.0.32555) or later
-- MathCAT 0.5.6 or later
+- NVDA Version 2025.1 or later.
+- MathCAT 0.6.10 or later
 
 # NVDA Settings
 
 ## Choosing your Voice Synthesizer:
 
 There are usually at least three choices: eSpeak NG, Microsoft Speech
-API, Windows OneCore voices. All synthesizers work, but the Windows
-OneCore voices don’t support speaking “a” properly and the other options
-should be used. In particular, the Microsoft Speech API is a good
-substitute for the OneCore voices.
-
-To change this:
-
-1.  Open NVDA
-2.  Start NVDA
-3.  Use the NVDA Key + n to bring up the NVDA Menu
-    1.  The NVDA Key is usually the INS key
-    2.  Alternatively, use the mouse to find the NVDA icon in the
-        toolbar. Note that the NVDA icon might be hidden. Use the show
-        hidden icons option to bring it up
-4.  Select Preferences from the NVDA Menu
-5.  Select Settings...
-6.  Go to Speech
-7.  The Windows OneCore voice will be the default under synthesizer,
-    activate the Change button
-8.  Select Microsoft Speech API version x (as of the time of writing
-    this document, version 5 is the latest)
-9.  Activate the "OK" button
-10. Activate the "Apply" button
-11. Activate the "OK" button to close the dialog
+API, and Windows OneCore voices. All synthesizers work.
 
 # Installing MathCAT Add-on:
 
-1.  Go to: [MathCAT Add-on
-    Page](https://addons.nvda-project.org/addons/MathCAT.en.html)
-2.  Activate the “Stable Version” link. This should be the 3<sup>rd</sup>
-    bullet that reads "Download Stable Version".
-3.  Find the file you downloaded and open it. A dialogue should come up
-    that says:  
-    “Are you sure you want to install this add-on? Only install add-ons
-    from trusted sources. Addon: MathCAT: speech and Braille from
-    MathML”
-4.  Select “Yes”
-5.  NVDA will ask you to restart, select “Yes”
+1.   Open NVDA settings with NVDA key + n and arrow down to the  Tools menu and press enter.
+2. Arrow don to the Ad-on store and press enter.
+  3. Press shift  tab untill you get to the installed Add-ons and arrow over to the Available Add-ons.
+  4. Press tab untill you get to the Search field and type in MathCAT and press enter.
+  6. Press enter and confirm that you want to install.
+  7. The MathCAT Add-on will be downloaded and installed.
+   8.  NVDA will ask you to restart, select “Yes”
+9. NVDA will restart with MathCAT enabled.
 
 # Accessing the MathCAT settings
 


### PR DESCRIPTION
This updates the NVDA suggested settings. It:
*  Suggests NVDA 2025.1 or later
*  suggest MathCAT 0.6.10 or later
* Explains in detail how to get the Add-on and the keystrokes for changing the settings
* Goes through all the Speech settings
* Goes through all the Navigation settings
Note: I could not get the navigation mode to accept verbose, it returns to medium. This is just before the option to copy as MathML.

We only have Richard and Brian as reviewers in this repo; I wanted to have Mary and Neil review.
